### PR TITLE
npm error Git working directory not clean.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,8 +26,6 @@ jobs:
         run: |
           git config user.email "webmaster@exploratorium.edu"
           git config user.name "the Exploratorium"
-      - name: Remove examples
-        run: rm -rf examples
       - name: Install dependencies
         run: npm ci
       - name: Increment version


### PR DESCRIPTION
This commit removes the steps for deleting examples from the npm-publish workflows and a redundant job name from the pr-checks workflow.