### PR TITLE
Add build step to npm-publish GitHub workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,8 @@ jobs:
           git config user.name "the Exploratorium"
       - name: Install dependencies
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Increment version
         run: |
           npm version patch

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/examples
+/rollup.config.js
+
+**/*.test.js


### PR DESCRIPTION
The workflow now includes a build step before version increment. This ensures that the latest build is available prior to publishing a new package version.

Created .npmignore files. This ensures that example directories, rollup configuration files, and test files are not included in the published npm packages.