### PR TITLE
Fixed bug where CSS file was named incorrectly

### DIFF
--- a/examples/examples.test.js
+++ b/examples/examples.test.js
@@ -90,7 +90,7 @@ describe('examples', () => {
         const yamlFilePath = `${sdc}/my-component.component.yml`;
         const content = await readFile(yamlFilePath, 'utf8');
         expect(content).toMatch(/\n\s*name:\s+My Component\n/);
-      });
+      }, 10_000);
     });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -17,15 +17,6 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
           `Working on ${bundleId} isEntry=${isEntry}, name=${name}, fileName=${fileName}, type=${type}`,
         );
 
-        if (bundleId === 'style.css') {
-          const cssFileName = basename(options.dir);
-          this.debug({
-            message: `Renaming ${bundleId} to ${cssFileName}.css`,
-          });
-          bundle[bundleId].fileName = `${cssFileName}.css`;
-          continue;
-        }
-
         if (type !== 'chunk' || !isEntry) {
           this.debug({ message: `Skipping ${bundleId}` });
           continue;
@@ -42,10 +33,8 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
               'utf8',
             );
 
-            const emittedFileName = join(
-              dirname(bundleId),
-              file.replace('[name]', name),
-            );
+            const emittedFileName = file.replace('[name]', name);
+            this.debug(`emitted filename is ${emittedFileName}`);
 
             const emittedSource = source
               .replaceAll(/(?<!\[)\[name](?!])/g, name)
@@ -63,6 +52,16 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
             this.emitFile(emittedFile);
           }),
         );
+      }
+    },
+    writeBundle(options, bundle) {
+      if (Object.hasOwn(bundle, 'style.css')) {
+        const bundleId = 'style.css';
+        const cssFileName = basename(options.dir);
+        this.debug({
+          message: `Renaming ${bundleId} to ${cssFileName}.css`,
+        });
+        bundle[bundleId].fileName = `${cssFileName}.css`;
       }
     },
   };

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,20 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
     async generateBundle(options, bundle) {
       for (const fileName in bundle) {
         const { isEntry, name, type } = bundle[fileName];
+        this.debug(
+          `Working on ${fileName} isEntry=${isEntry}, name=${name}, type=${type}`,
+        );
 
         if (fileName === 'style.css') {
+          this.debug({
+            message: `Renaming ${fileName} to ${basename(options.dir)}.css`,
+          });
           bundle[fileName].fileName = `${basename(options.dir)}.css`;
           continue;
         }
 
         if (type !== 'chunk' || !isEntry) {
+          this.debug({ message: `Skipping ${fileName}` });
           continue;
         }
 
@@ -27,7 +34,7 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
           typeof directory === 'object' ? directory[name] : directory;
         const files = await readdir(templateDirectory);
 
-        return Promise.all(
+        await Promise.all(
           files.map(async (file) => {
             const source = await readFile(
               join(templateDirectory, file),
@@ -49,6 +56,9 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
               source: emittedSource,
             };
 
+            this.debug({
+              message: `Emitting ${fileName} => ${emittedFile.fileName}`,
+            });
             this.emitFile(emittedFile);
           }),
         );

--- a/src/index.js
+++ b/src/index.js
@@ -11,22 +11,23 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
   return {
     name: 'rollup-plugin-drupal-sdc-generator',
     async generateBundle(options, bundle) {
-      for (const fileName in bundle) {
-        const { isEntry, name, type } = bundle[fileName];
+      for (const bundleId in bundle) {
+        const { isEntry, name, fileName, type } = bundle[bundleId];
         this.debug(
-          `Working on ${fileName} isEntry=${isEntry}, name=${name}, type=${type}`,
+          `Working on ${bundleId} isEntry=${isEntry}, name=${name}, fileName=${fileName}, type=${type}`,
         );
 
-        if (fileName === 'style.css') {
+        if (bundleId === 'style.css') {
+          const cssFileName = basename(options.dir);
           this.debug({
-            message: `Renaming ${fileName} to ${basename(options.dir)}.css`,
+            message: `Renaming ${bundleId} to ${cssFileName}.css`,
           });
-          bundle[fileName].fileName = `${basename(options.dir)}.css`;
+          bundle[bundleId].fileName = `${cssFileName}.css`;
           continue;
         }
 
         if (type !== 'chunk' || !isEntry) {
-          this.debug({ message: `Skipping ${fileName}` });
+          this.debug({ message: `Skipping ${bundleId}` });
           continue;
         }
 
@@ -42,7 +43,7 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
             );
 
             const emittedFileName = join(
-              dirname(fileName),
+              dirname(bundleId),
               file.replace('[name]', name),
             );
 
@@ -57,7 +58,7 @@ function drupalSdcGenerator({ directory: _directory } = {}) {
             };
 
             this.debug({
-              message: `Emitting ${fileName} => ${emittedFile.fileName}`,
+              message: `Emitting ${bundleId} => ${emittedFile.fileName}`,
             });
             this.emitFile(emittedFile);
           }),

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,33 +4,32 @@ import { describe, expect, test } from '@jest/globals';
 import drupalSdcGenerator from './index.js';
 
 describe('drupalSdcGenerator', () => {
-  test('plugin has a name', () => {
-    const instance = drupalSdcGenerator();
+  const instance = {
+    // eslint-disable-next-line no-undef
+    ...console,
+    debug: () => {},
+    ...drupalSdcGenerator(),
+  };
 
+  const options = {
+    dir: 'baz',
+  };
+
+  const bundle = {
+    'baz.js': { isEntry: true, name: 'baz', type: 'chunk' },
+    'style.css': {
+      isEntry: undefined,
+      name: 'style.css',
+      type: 'asset',
+    },
+  };
+
+  test('plugin has a name', () => {
     expect(instance).toHaveProperty('name');
   });
 
   test('generates a bundle', async () => {
-    const instance = {
-      // eslint-disable-next-line no-undef
-      ...console,
-      debug: () => {},
-      ...drupalSdcGenerator(),
-    };
     instance.emitFile = jest.fn();
-
-    const options = {
-      dir: 'baz',
-    };
-
-    const bundle = {
-      'baz.js': { isEntry: true, name: 'baz', type: 'chunk' },
-      'style.css': {
-        isEntry: undefined,
-        name: 'style.css',
-        type: 'asset',
-      },
-    };
 
     await instance.generateBundle(options, bundle);
 
@@ -45,6 +44,10 @@ describe('drupalSdcGenerator', () => {
         }),
       );
     });
+  });
+
+  test('writeBundle renames style.css to [name].css', () => {
+    instance.writeBundle(options, bundle);
 
     expect(bundle['style.css'].fileName).toEqual('baz.css');
   });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -12,6 +12,7 @@ describe('drupalSdcGenerator', () => {
 
   test('generates a bundle', async () => {
     const instance = {
+      // eslint-disable-next-line no-undef
       ...console,
       debug: () => {},
       ...drupalSdcGenerator(),
@@ -19,13 +20,16 @@ describe('drupalSdcGenerator', () => {
     instance.emitFile = jest.fn();
 
     const options = {
-      // eslint-disable-next-line no-undef
-      dir: process.cwd(),
+      dir: 'baz',
     };
 
     const bundle = {
       'baz.js': { isEntry: true, name: 'baz', type: 'chunk' },
-      'styles.css': { isEntry: undefined, name: 'styles.css', type: 'asset' },
+      'style.css': {
+        isEntry: undefined,
+        name: 'style.css',
+        type: 'asset',
+      },
     };
 
     await instance.generateBundle(options, bundle);
@@ -41,5 +45,7 @@ describe('drupalSdcGenerator', () => {
         }),
       );
     });
+
+    expect(bundle['style.css'].fileName).toEqual('baz.css');
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,11 +6,16 @@ import drupalSdcGenerator from './index.js';
 describe('drupalSdcGenerator', () => {
   test('plugin has a name', () => {
     const instance = drupalSdcGenerator();
+
     expect(instance).toHaveProperty('name');
   });
 
   test('generates a bundle', async () => {
-    const instance = drupalSdcGenerator();
+    const instance = {
+      ...console,
+      debug: () => {},
+      ...drupalSdcGenerator(),
+    };
     instance.emitFile = jest.fn();
 
     const options = {
@@ -20,6 +25,7 @@ describe('drupalSdcGenerator', () => {
 
     const bundle = {
       'baz.js': { isEntry: true, name: 'baz', type: 'chunk' },
+      'styles.css': { isEntry: undefined, name: 'styles.css', type: 'asset' },
     };
 
     await instance.generateBundle(options, bundle);


### PR DESCRIPTION
The CSS files were not named according to the requirements for Drupal Single Directory Components, so they had to be updated. 