### PR TITLE
remove duplicate eslint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
       ],
       "license": "MIT",
       "devDependencies": {
-        "@eslint/js": "^9.14.0",
         "@jest/globals": "^29.7.0",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --config jest.config.cjs"
   },
   "devDependencies": {
-    "@eslint/js": "^9.14.0",
     "@jest/globals": "^29.7.0",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",


### PR DESCRIPTION
Both `eslint` and `@eslint/js` are not needed