### PR TITLE
Fix npm publish: add contents: write permission to workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: write` to the `publish-npm` job so `GITHUB_TOKEN` has the access needed to run `git push --follow-tags`
- Without this, GitHub Actions defaults to read-only token permissions and the publish step fails

## Test plan

- [ ] Merge and confirm the next push to `main` runs the full npm-publish workflow without a 403 on the push step

🤖 Generated with [Claude Code](https://claude.com/claude-code)