### PR TITLE
Switch npm publish to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,5 +39,3 @@ jobs:
           git push --follow-tags
       - name: Publish to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission so the workflow can request an OIDC token from GitHub
- Removes `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret — npm authenticates via the OIDC token when the repo is configured as a Trusted Publisher on npmjs.com

## Test plan

- [ ] Merge and confirm the next push to `main` publishes successfully without OTP error

🤖 Generated with [Claude Code](https://claude.com/claude-code)