### PR TITLE
Remove registry-url from setup-node to fix OIDC publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,12 +19,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
       - name: Configure Git
         run: |
           git config user.email "webmaster@exploratorium.edu"


### PR DESCRIPTION
## Summary

- Removes `registry-url: 'https://registry.npmjs.org'` from the `setup-node` step
- When `registry-url` is set, `actions/setup-node` writes an `.npmrc` that configures `NODE_AUTH_TOKEN` for token-based auth — this conflicts with npm Trusted Publisher OIDC authentication and causes a `404 Not Found` on publish
- With `registry-url` removed, npm's CLI handles the OIDC token exchange automatically

## Test plan

- [ ] Merge and confirm the next push to `main` publishes to npm without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)