### PR TITLE
Restore registry-url for npm Trusted Publisher OIDC flow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Configure Git
         run: |
           git config user.email "webmaster@exploratorium.edu"


### PR DESCRIPTION
## Summary

- Restores `registry-url: 'https://registry.npmjs.org'` to the `setup-node` step
- Without it, no `.npmrc` is created and npm fails with `ENEEDAUTH`
- The workflow uses `id-token: write` + no `NODE_AUTH_TOKEN` for OIDC Trusted Publisher auth

## Note

If this still fails with `E404`, the issue is a mismatch in the npm Trusted Publisher configuration (wrong workflow filename, repository, or environment field) — not the workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)