### PR TITLE
Unset NODE_AUTH_TOKEN to fix npm OIDC Trusted Publisher flow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,4 +37,4 @@ jobs:
           npm version patch
           git push --follow-tags
       - name: Publish to NPM
-        run: npm publish --access public
+        run: env -u NODE_AUTH_TOKEN npm publish --access public


### PR DESCRIPTION
## Summary

- Changes `npm publish` to run as `env -u NODE_AUTH_TOKEN npm publish --access public`
- When `NODE_AUTH_TOKEN` is set (even implicitly by `setup-node`), npm skips the OIDC exchange and sends it directly as a bearer token — npm's registry rejects this with `E404`
- Explicitly unsetting it forces npm CLI to detect the GitHub Actions OIDC environment and perform the proper token exchange with audience `npm`, which is what npm's Trusted Publisher verification expects

## Test plan

- [ ] Merge and confirm publish succeeds without E404

🤖 Generated with [Claude Code](https://claude.com/claude-code)