### PR TITLE
Update actions/checkout and actions/setup-node to fix Node 20 deprecation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,9 +18,9 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js.
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
       - name: Install dependencies.
@@ -34,11 +34,11 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Checkout code.
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v7
 #      - name: Setup Node.js.
-#        uses: actions/setup-node@v4
+#        uses: actions/setup-node@v6
 #        with:
-#          node-version: '20.x'
+#          node-version: '22.x'
 #      - name: Extract version from package.json
 #        uses: sergeysova/jq-action@v2
 #        id: name


### PR DESCRIPTION
## Summary

- `actions/checkout`: v4 → v7
- `actions/setup-node`: v4 → v6

Both updated in `npm-publish.yml` and `pr-checks.yml`. The old v4 versions targeted Node.js 20 internally, causing the deprecation warning on GitHub's runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)